### PR TITLE
Change "Not Applicable" to "N/A" for "Largest Park"

### DIFF
--- a/data/city_average.json
+++ b/data/city_average.json
@@ -1,1 +1,1 @@
-{"dog_parks": 0.049, "picnic": 5.037, "playgrounds": 0.72, "activities": 0.134, "restrooms": 0.463, "trail": 0.552, "event_space": 0.341, "number_of_parks": 1.28, "fields": 3.159, "total_park_acres": 47.214, "biggest_park": "Not Applicable", "gardens": 0.073}
+{"dog_parks": 0.049, "picnic": 5.037, "playgrounds": 0.72, "activities": 0.134, "restrooms": 0.463, "trail": 0.552, "event_space": 0.341, "number_of_parks": 1.28, "fields": 3.159, "total_park_acres": 47.214, "biggest_park": "N/A", "gardens": 0.073}


### PR DESCRIPTION
Change average stats to read "N/A" for largest park instead of "Not Applicable" to match neighborhood stats for neighborhoods with no parks.
